### PR TITLE
fix/plugin overwrite user keybinding

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -15,7 +15,7 @@ function init()
 	config.TryBindKey("F12", "command:makeup", true)
 
 	config.MakeCommand("makeupbg", makeupbgCommand, config.NoComplete)
-	config.TryBindKey("F9", "command:makeupbg", true)	
+	config.TryBindKey("F9", "command:makeupbg", true)
 end
 
 -- ### F5 runit ###
@@ -33,15 +33,15 @@ function runitCommand(bp) -- bp BufPane
 		-- c compilation only supported on Linux-like systems
 		shell.RunInteractiveShell("clear", false, false)
 
-		-- we must create the temporary file here 
-		-- so that local attacker can't create a hostile one beforehand		
+		-- we must create the temporary file here
+		-- so that local attacker can't create a hostile one beforehand
 		-- RunInteractiveShell(input string, wait bool, getOutput bool) (string, error)
 		cmd = string.format("mktemp '/tmp/micro-run-binary-XXXXXXXXXXX'", filename)
 		tmpfile, err = shell.RunInteractiveShell(cmd, false, true)
 		-- TODO: error handling
 
 		shell.RunInteractiveShell("echo", false, false)
-		
+
 		-- compile to temporary file with unique(ish) tmp file name
 		cmd = string.format("gcc '%s' -o '%s'", filename, tmpfile)
 		shell.RunInteractiveShell(cmd, false, false)
@@ -61,15 +61,15 @@ function runitCommand(bp) -- bp BufPane
 		-- Rust rs is handled like C.
 		shell.RunInteractiveShell("clear", false, false)
 
-		-- we must create the temporary file here 
-		-- so that local attacker can't create a hostile one beforehand		
+		-- we must create the temporary file here
+		-- so that local attacker can't create a hostile one beforehand
 		-- RunInteractiveShell(input string, wait bool, getOutput bool) (string, error)
 		cmd = string.format("mktemp '/tmp/micro-run-binary-XXXXXXXXXXX'", filename)
 		tmpfile, err = shell.RunInteractiveShell(cmd, false, true)
 		-- TODO: error handling
 
 		shell.RunInteractiveShell("echo", false, false)
-		
+
 		-- compile to temporary file with unique(ish) tmp file name
 		cmd = string.format("rustc '%s' -o '%s'", filename, tmpfile)
 		shell.RunInteractiveShell(cmd, false, false)
@@ -104,7 +104,7 @@ function runitCommand(bp) -- bp BufPane
 	end
 
 	shell.RunInteractiveShell("clear", false, false)
-	shell.RunInteractiveShell(cmd, true, false)		
+	shell.RunInteractiveShell(cmd, true, false)
 end
 
 -- ### F12 makeup ###
@@ -120,7 +120,7 @@ end
 function makeupbgCommand(bp)
 	-- run make in this or higher directory, in the background, hide most output
 	bp:Save()
-	makeupWrapper(true)	
+	makeupWrapper(true)
 end
 
 function makeJobExit(out, args)
@@ -159,13 +159,13 @@ function makeupWrapper(bg)
 end
 
 function makeup(bg)
-	-- Go up directories until a Makefile is found and run 'make'. 
-	-- 'bg' means run in background, hiding most 'make' output. 
-	
+	-- Go up directories until a Makefile is found and run 'make'.
+	-- 'bg' means run in background, hiding most 'make' output.
+
 	-- Caller is responsible for returning to original working directory.
-	-- Important, because micro will save the current file into the directory where 
-	-- we are in. In this plugin, makeupWrapper() implements returning 
-	-- to original directory. 
+	-- Important, because micro will save the current file into the directory where
+	-- we are in. In this plugin, makeupWrapper() implements returning
+	-- to original directory.
 
 	local err, pwd, prevdir
 	for i = 1,20 do -- arbitrary number to make sure we exit one day
@@ -208,10 +208,10 @@ function makeup(bg)
 			micro.InfoBar():Message("Error: os.Chdir() failed!")
 			return
 		end
-		
+
 	end
 	micro.InfoBar():Message("Warning: ran full 20 rounds but did not recognize root directory")
 	return
 
-end	
+end
 

--- a/main.lua
+++ b/main.lua
@@ -9,13 +9,13 @@ local os = import("os")
 
 function init()
 	config.MakeCommand("runit", runitCommand, config.NoComplete)
-	config.TryBindKey("F5", "command:runit", true)
+	config.TryBindKey("F5", "command:runit", false)
 
 	config.MakeCommand("makeup", makeupCommand, config.NoComplete)
-	config.TryBindKey("F12", "command:makeup", true)
+	config.TryBindKey("F12", "command:makeup", false)
 
 	config.MakeCommand("makeupbg", makeupbgCommand, config.NoComplete)
-	config.TryBindKey("F9", "command:makeupbg", true)
+	config.TryBindKey("F9", "command:makeupbg", false)
 end
 
 -- ### F5 runit ###


### PR DESCRIPTION
- style(source): remove trailing spaces
- fix(keybindings): avoid change the user pre-existing keybindings
